### PR TITLE
fix: The table style inccrect in markdown file

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -35,7 +35,7 @@
         @extend .img-fluid;
     }
 
-    > table {
+    table {
         @extend .table-striped;
 
         @extend .table-responsive;


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

now:
![截屏2022-05-13 15 51 50](https://user-images.githubusercontent.com/33231138/168237368-fe7bd525-bf3a-4e1b-b20e-b39c6a5608d9.png)

It's related to ##61