### PR TITLE
Add tip for EIP object address field in Usage / Use OpenELB in BGP Mode

### DIFF
--- a/content/en/docs/getting-started/usage/use-openelb-in-bgp-mode.md
+++ b/content/en/docs/getting-started/usage/use-openelb-in-bgp-mode.md
@@ -208,6 +208,7 @@ The Eip object functions as an IP address pool for OpenELB.
 
    {{< notice note >}}
 
+   The address can be any random but valid IP address representation (one or more), execpt the IP addresses already in use.
    For details about the fields in the Eip YAML configuration, see [Configure IP Address Pools Using Eip](/docs/getting-started/configuration/configure-ip-address-pools-using-eip/).
 
    {{</ notice >}}


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>

Fixes #65 

A tip for the address field in EIP object  added in [Getting Started / Usage / Use OpenELB in BGP mode](https://website-openelb.vercel.app/docs/getting-started/usage/use-openelb-in-bgp-mode/) section of the documentation.