### PR TITLE
 Add protocol device in bird configuration of Usage / Use OpenELB in BGP Mode

### DIFF
--- a/content/en/docs/getting-started/usage/use-openelb-in-bgp-mode.md
+++ b/content/en/docs/getting-started/usage/use-openelb-in-bgp-mode.md
@@ -61,6 +61,10 @@ If you use a real router, you can skip this step and perform configuration on th
        export all;
        merge paths on;
    }
+
+   protocol device {
+       scan time 60;
+   }
    
    protocol bgp neighbor1 {
        local as 50001;


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>

Fixes #67 

`protocol device {}` added in the bird configuration in [Getting Started / Usage / Use OpenELB in BGP mode](https://website-openelb.vercel.app/docs/getting-started/usage/use-openelb-in-bgp-mode/) section of the documentation in order to avoid readers from getting bird related errors.