### PR TITLE
add alert message to avoid using eip address in can_reach field of EIP

### DIFF
--- a/content/en/docs/getting-started/configuration/configure-ip-address-pools-using-eip.md
+++ b/content/en/docs/getting-started/configuration/configure-ip-address-pools-using-eip.md
@@ -86,7 +86,7 @@ The fields are described as follows:
 
   {{< notice tip >}}
 
-  If the NIC names of the Kubernetes cluster nodes are different, you can set the value to `can_reach:IP address` (for example, `can_reach:192.168.0.5`) so that OpenELB automatically obtains the name of the NIC that can reach the IP address. In this case, you must ensure that the IP address is not used by Kubernetes cluster nodes but can be reached by the cluster nodes.
+  If the NIC names of the Kubernetes cluster nodes are different, you can set the value to `can_reach:IP address` (for example, `can_reach:192.168.0.5`) so that OpenELB automatically obtains the name of the NIC that can reach the IP address. In this case, you must ensure that the IP address is not used by Kubernetes cluster nodes but can be reached by the cluster nodes.Also, do not use addresses configured in EIPs here.
 
   {{</ notice >}}
 


### PR DESCRIPTION
I have tried using one of the eip address in EIP can_reach field and facts have proved better not do so.
I have created an issue which has the detail of problems I met:  https://github.com/openelb/openelb/issues/331
Maybe it's better to add some direct instructions in doc to avoid users from repeating trying this.